### PR TITLE
Fixes for Issue #7

### DIFF
--- a/appdir/AppRun
+++ b/appdir/AppRun
@@ -1,5 +1,5 @@
 #! /bin/sh
 
-export LD_LIBRARY_PATH=$APPDIR/usr/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$APPDIR/usr/lib:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 export PATH=$APPDIR/bin:$APPDIR/sbin:$APPDIR/usr/bin:$APPDIR/usr/sbin:$PATH
 exec $APPDIR/znx-gui $@


### PR DESCRIPTION
From the error it seemed that some library was missing, but the lib directory had the mentioned libraries in the error.

On running `ldd` on `kdialog` some libraries were shown to be not found.

Hence explicitly adding all the lib directories in `$LD_LIBRARY_PATH` fixed the issue. 